### PR TITLE
Upgrade to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,14 @@ documentation = "https://docs.rs/bevy_generative"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = { version = "0.13.0", default-features = false, features = ["bevy_core_pipeline", "bevy_pbr", "bevy_ui"] }
+bevy = { version = "0.14.0", default-features = false, features = [
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_ui",
+] }
 colorgrad = "0.6.2"
 gltf = "1.3.0"
-image = "0.24.7"
+image = "0.25"
 noise = { version = "0.9.0", git = "https://github.com/Razaekel/noise-rs.git" }
 rfd = "0.12.1"
 serde = "1.0.195"
@@ -34,4 +38,3 @@ opt-level = 1
 
 [profile.release]
 lto = "thin"
-

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -171,8 +171,8 @@ fn generate_terrain(
         let mut indices: Vec<u32> = Vec::with_capacity(triangle_count);
         let mut colors: Vec<[f32; 4]> = Vec::with_capacity(vertices_count);
 
-        let rows = terrain.size[0] * terrain.resolution + 1;
-        let cols = terrain.size[1] * terrain.resolution + 1;
+        let rows = terrain.size[0] * terrain.resolution;
+        let cols = terrain.size[1] * terrain.resolution;
         let width = terrain.size[0] as f32 + 1.0;
         let depth = terrain.size[1] as f32 + 1.0;
         for row in 0..rows {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -24,7 +24,7 @@ pub fn export_asset(image_buffer: ImageBuffer<Rgba<u8>, Vec<u8>>) {
                 &image_buffer,
                 image_buffer.width(),
                 image_buffer.height(),
-                color_type,
+                color_type.into(),
             )
             .expect("Failed to write to png");
 


### PR DESCRIPTION
Upgrades to Bevy 0.14
Fixes #4 

- Update `bevy` dep
- Update `image` dep to match `bevy`'s
- One easy migration for `bevy`'s changes to `Color`.

This also fixes a panic in `terrain.rs` which was unrelated to the Bevy upgrade.

I tested this with the examples from `README.md`. Those examples work as-is with Bevy 0.14 and don't require any changes. (Except for the previously mentioned panic related to terrain)

I would love to add these examples as cargo examples (I did this while testing), but I've omitted that here to keep things simple. I can follow up with that later if you're agreeable.
