### PR TITLE
Add cargo examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ serde = "1.0.195"
 serde_json = "1.0.111"
 wasm-bindgen = "0.2.89"
 
+[dev-dependencies]
+bevy = "0.14.0"
+
 # Enable max optimizations for dependencies, but not for our code:
 [profile.dev.package."*"]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -31,81 +31,10 @@ cargo add bevy_generative
 
 ## Examples
 
-### Maps and Textures
+Examples are provided in the [examples](./examples) directory. To run an example, clone this repository and invoke cargo like this:
 
-```rust
-use bevy::prelude::*;
-use bevy_generative::map::{MapBundle, MapPlugin};
-
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugins(MapPlugin)
-        .add_systems(Startup, setup)
-        .run();
-}
-
-fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn(MapBundle::default());
-}
-
-```
-
-### Terrain
-
-```rust
-use bevy::prelude::*;
-use bevy_generative::terrain::{TerrainBundle, TerrainPlugin};
-
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugins(TerrainPlugin)
-        .add_systems(Startup, setup)
-        .run();
-}
-
-fn setup(mut commands: Commands) {
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
-    commands.spawn(TerrainBundle::default());
-}
-
-```
-
-### Planets
-
-```rust
-use bevy::prelude::*;
-use bevy_generative::planet::{PlanetBundle, PlanetPlugin};
-
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugins(PlanetPlugin)
-        .add_systems(Startup, setup)
-        .run();
-}
-
-fn setup(mut commands: Commands) {
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
-    commands.spawn(PlanetBundle::default());
-}
-
+```sh
+cargo run --example map
 ```
 
 ## Bevy Compatibility

--- a/examples/export.rs
+++ b/examples/export.rs
@@ -1,0 +1,78 @@
+use bevy::prelude::*;
+use bevy_generative::terrain::{Terrain, TerrainBundle, TerrainPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TerrainPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (button_appearance, export_button))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+    commands.spawn(TerrainBundle::default());
+
+    commands
+        .spawn(ButtonBundle {
+            style: Style {
+                padding: UiRect::all(Val::Px(12.)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                margin: UiRect::all(Val::Px(12.)),
+                ..default()
+            },
+            border_radius: BorderRadius::all(Val::Px(5.)),
+            background_color: NORMAL_BUTTON.into(),
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn(TextBundle::from_section(
+                "Export",
+                TextStyle {
+                    font_size: 30.0,
+                    color: BUTTON_TEXT.into(),
+                    ..default()
+                },
+            ));
+        });
+}
+
+fn export_button(
+    interaction_query: Query<&Interaction, (Changed<Interaction>, With<Button>)>,
+    mut terrain_query: Query<&mut Terrain>,
+) {
+    if interaction_query.iter().any(|i| *i == Interaction::Pressed) {
+        for mut terrain in &mut terrain_query {
+            terrain.export = true;
+        }
+    }
+}
+
+const NORMAL_BUTTON: Srgba = bevy::color::palettes::tailwind::BLUE_500;
+const HOVERED_BUTTON: Srgba = bevy::color::palettes::tailwind::BLUE_600;
+const PRESSED_BUTTON: Srgba = bevy::color::palettes::tailwind::BLUE_700;
+const BUTTON_TEXT: Srgba = bevy::color::palettes::tailwind::BLUE_50;
+
+fn button_appearance(
+    mut interaction_query: Query<
+        (&Interaction, &mut BackgroundColor),
+        (Changed<Interaction>, With<Button>),
+    >,
+) {
+    for (interaction, mut color) in &mut interaction_query {
+        *color = match *interaction {
+            Interaction::Pressed => PRESSED_BUTTON.into(),
+            Interaction::Hovered => HOVERED_BUTTON.into(),
+            Interaction::None => NORMAL_BUTTON.into(),
+        }
+    }
+}

--- a/examples/map.rs
+++ b/examples/map.rs
@@ -1,0 +1,15 @@
+use bevy::prelude::*;
+use bevy_generative::map::{MapBundle, MapPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(MapPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(MapBundle::default());
+}

--- a/examples/planet.rs
+++ b/examples/planet.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+use bevy_generative::planet::{PlanetBundle, PlanetPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PlanetPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+    commands.spawn(PlanetBundle::default());
+}

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -1,0 +1,28 @@
+use bevy::prelude::*;
+use bevy_generative::terrain::{TerrainBundle, TerrainPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TerrainPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+    commands.spawn(TerrainBundle {
+        terrain: bevy_generative::terrain::Terrain {
+            resolution: 4,
+            ..default()
+        },
+        ..default()
+    });
+}


### PR DESCRIPTION
This is a lightweight version of #3 with minimal changes.

- Moved examples from `README` into an `examples` folder without any modifications
- Added an example demonstrating the export functionality as requested in #3

Closes #3 